### PR TITLE
Optimize RUN commands for minimal image size.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,11 @@ RUN sed -i.bak "s/<mirror>/http:\/\/mirror.internode.on.net\/pub\/ubuntu\/ubuntu
 
 # Upgrade all currently installed packages and install web server packages.
 RUN apt-get update \
-&& apt-get -y install python-software-properties software-properties-common \
-&& apt-get update \
 && apt-get -y dist-upgrade \
 && apt-get -y install apache2 \
 && apt-get -y install php7.0 php7.0-cli php7.0-common libapache2-mod-php7.0 php-apcu php7.0-curl php7.0-gd php7.0-ldap php7.0-mysql php7.0-opcache php-xdebug php7.0-xml php7.0-mbstring php7.0-bcmath libedit-dev \
 && apt-get -y install ssmtp \
-&& apt-get -y autoclean && apt-get clean && rm -rf /var/lib/apt /tmp/* /var/tmp/*
+&& apt-get -y autoremove && apt-get -y autoclean && apt-get clean && rm -rf /var/lib/apt /tmp/* /var/tmp/*
 
 # Apache config.
 COPY ./files/apache2-foreground /usr/local/bin/apache2-foreground


### PR DESCRIPTION
Gets the image down to 339.3 MB from 365.2 MB.

It's an improvement - but I hoped for more.

I wonder about some of the things we install... 
`docker history` for the original image:

```
IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
e26db9121c6a        40 minutes ago      /bin/sh -c #(nop) CMD ["/usr/local/bin/apache   0 B                 
c3308f5a91fc        40 minutes ago      /bin/sh -c ln -sf /dev/stderr /var/log/apache   11 B                
b8e8ef6e15bb        40 minutes ago      /bin/sh -c ln -sf /dev/stdout /var/log/apache   11 B                
cbbb3757c111        40 minutes ago      /bin/sh -c #(nop) WORKDIR /web                  0 B                 
b9d73c43a4c6        40 minutes ago      /bin/sh -c #(nop) EXPOSE 443/tcp 80/tcp         0 B                 
818e8e3ebe9d        40 minutes ago      /bin/sh -c apt-get clean && rm -rf /var/lib/a   0 B                 
ca0a06c2a408        40 minutes ago      /bin/sh -c apt-get -y autoclean                 0 B                 
3767deb7398b        40 minutes ago      /bin/sh -c a2dissite 000-default                0 B                 
afff9f1970e6        40 minutes ago      /bin/sh -c chmod +x /usr/local/bin/apache2-fo   342 B               
c20afd5592ba        40 minutes ago      /bin/sh -c phpenmod -v ALL -s ALL sendmail      80 B                
45aa385063f4        40 minutes ago      /bin/sh -c echo "mailhub=mail:25\nUseTLS=NO\n   47 B                
3b1284477546        40 minutes ago      /bin/sh -c echo "sendmail_path = /usr/sbin/ss   35 B                
c6b85ebac005        40 minutes ago      /bin/sh -c apt-get -y install ssmtp             2.523 MB            
d4d0273631c4        40 minutes ago      /bin/sh -c phpenmod -v ALL -s ALL xdebug        0 B                 
4e25da00adb2        40 minutes ago      /bin/sh -c #(nop) COPY file:637d35ca788d54d57   1.561 kB            
dfa2440ec8af        40 minutes ago      /bin/sh -c #(nop) COPY file:139fb2bc454dd3da9   342 B               
331f4d2591bb        40 minutes ago      /bin/sh -c apt-get -y install php7.0 php7.0-c   33.18 MB            
03b6de6e097c        41 minutes ago      /bin/sh -c a2dismod vhost_alias                 0 B                 
e7da342b1dd4        41 minutes ago      /bin/sh -c a2enmod rewrite                      30 B                
da233249d81f        41 minutes ago      /bin/sh -c echo "Australia/Adelaide" > /etc/t   1.478 MB            
d8f7c4e17b2b        41 minutes ago      /bin/sh -c apt-get -y install apache2           50.49 MB            
7c82bd8b9576        41 minutes ago      /bin/sh -c apt-get -y dist-upgrade              0 B                 
e340d71dbb96        41 minutes ago      /bin/sh -c apt-get update                       434.6 kB            
44d7f939c449        41 minutes ago      /bin/sh -c apt-get -y install python-software   135.5 MB            
74268b0521c5        42 minutes ago      /bin/sh -c apt-get update                       19.22 MB            
9ab19e4b6b0b        42 minutes ago      /bin/sh -c sed -i.bak "s/<version>/$(sed -n "   2.684 kB            
55e3ec778969        42 minutes ago      /bin/sh -c sed -i.bak "s/<mirror>/http:\/\/mi   2.24 kB             
0818e8a5250b        42 minutes ago      /bin/sh -c #(nop) COPY file:23e047cb21e2f9791   880 B               
910dafc4eb02        42 minutes ago      /bin/sh -c #(nop) ENV LC_ALL=en_AU.UTF-8        0 B                 
881fee08f4f9        42 minutes ago      /bin/sh -c #(nop) ENV LANG=en_AU.UTF-8          0 B                 
e5685e4eebe3        42 minutes ago      /bin/sh -c locale-gen en_AU.UTF-8               1.678 MB            
0e21f5c9bb1f        42 minutes ago      /bin/sh -c #(nop) ENV DEBIAN_FRONTEND=noninte   0 B                 
c5f1cf30c96b        7 days ago          /bin/sh -c #(nop) CMD ["/bin/bash"]             0 B                 
<missing>           7 days ago          /bin/sh -c sed -i 's/^#\s*\(deb.*universe\)$/   1.895 kB            
<missing>           7 days ago          /bin/sh -c rm -rf /var/lib/apt/lists/*          0 B                 
<missing>           7 days ago          /bin/sh -c set -xe   && echo '#!/bin/sh' > /u   701 B               
<missing>           7 days ago          /bin/sh -c #(nop) ADD file:ffc85cfdb5e66a5b4f   120.8 MB
```

135.5 MB for python-software-properties & software-properties-common seems insane.
