### PR TITLE
Fix symlink creation when /code/web/sites/default isn't writeable

### DIFF
--- a/files/apache2-foreground
+++ b/files/apache2-foreground
@@ -21,7 +21,9 @@ if [ -n "${PUBLIC_DIR:+1}" ]; then
   chown -R www-data:www-data /shared/public
   # Only create symlink if it does not already exist.
   if [ ! -h /code/web/sites/default/files ]; then
+    chmod 0775 /code/web/sites/default/
     ln -sf ${PUBLIC_DIR} /code/web/sites/default/files
+    chmod 0555 /code/web/sites/default/
   fi
 fi
 


### PR DESCRIPTION
Fixes https://github.com/universityofadelaide/shepherd-drupal-scaffold/pull/40#issuecomment-409444025